### PR TITLE
👷 ci: remove push event trigger from PR build check workflow

### DIFF
--- a/.github/workflows/pr-build-check.yml
+++ b/.github/workflows/pr-build-check.yml
@@ -3,11 +3,6 @@ name: PR build check
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    
-on:
-  push:
-    branches:
-      - main
 
 jobs:
   build:


### PR DESCRIPTION
- delete push event from workflow triggers to streamline CI process