### PR TITLE
🐛 fix(storage): improve S3-compatible provider support and error hand…

### DIFF
--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -93,18 +93,19 @@ async function startServer() {
                         2,
                     ),
                 )
+            } else {
+                console.error(
+                    JSON.stringify(
+                        {
+                            type: "error",
+                            message: "Unknown error",
+                            cause: error,
+                        },
+                        undefined,
+                        2,
+                    ),
+                )
             }
-            console.error(
-                JSON.stringify(
-                    {
-                        type: "error",
-                        message: "Unknown error",
-                        cause: error,
-                    },
-                    undefined,
-                    2,
-                ),
-            )
 
             console.error("Restarting in 3 seconds...")
             await new Promise((resolve) => setTimeout(resolve, 3000))

--- a/packages/api/src/utilities/storage/ensureStorageBucket.ts
+++ b/packages/api/src/utilities/storage/ensureStorageBucket.ts
@@ -1,13 +1,14 @@
 import type { S3 } from "@aws-sdk/client-s3"
-import { CreateBucketCommand, HeadBucketCommand } from "@aws-sdk/client-s3"
+import { CreateBucketCommand, HeadBucketCommand, type HeadBucketCommandOutput } from "@aws-sdk/client-s3"
 
 /**
  * Ensures the storage bucket exists, creating it if necessary.
  * Should be called once at server startup.
  */
 export async function ensureStorageBucket(client: S3, bucketName: string) {
+    let headResult: HeadBucketCommandOutput | undefined
     try {
-        await client.send(new HeadBucketCommand({ Bucket: bucketName }))
+        headResult = await client.send(new HeadBucketCommand({ Bucket: bucketName }))
     } catch (error: unknown) {
         const name = error instanceof Object && "name" in error ? (error as { name: string }).name : undefined
         const httpStatusCode =
@@ -18,12 +19,25 @@ export async function ensureStorageBucket(client: S3, bucketName: string) {
                 ? (error.$metadata as { httpStatusCode: number }).httpStatusCode
                 : undefined
 
-        if (name === "NotFound" || name === "NoSuchBucket" || httpStatusCode === 404 || httpStatusCode === 403) {
+        if (name === "NotFound" || name === "NoSuchBucket" || httpStatusCode === 404) {
             console.info(`Bucket "${bucketName}" not found, creating it...`)
             await client.send(new CreateBucketCommand({ Bucket: bucketName }))
             console.info(`Bucket "${bucketName}" created.`)
-        } else {
-            throw error
+            return
         }
+
+        // Some S3-compatible providers (OpenStack Swift, etc.) return 400
+        // or other non-standard codes for HeadBucket. Log and continue
+        // rather than crashing the server — actual storage operations
+        // will surface real errors at request time.
+        console.warn(
+            `HeadBucket check failed (HTTP ${httpStatusCode ?? "unknown"}, name: ${name ?? "unknown"}). ` +
+                `Assuming bucket "${bucketName}" exists. Storage errors will surface at request time if misconfigured.`,
+        )
+        return
+    }
+
+    if (headResult) {
+        console.info(`Bucket "${bucketName}" is accessible.`)
     }
 }

--- a/packages/api/src/utilities/storage/generatePutSignedUrl.ts
+++ b/packages/api/src/utilities/storage/generatePutSignedUrl.ts
@@ -19,7 +19,6 @@ export async function generatePutSignedUrl(parameters: {
         const signedUrl = await getSignedUrl(
             parameters.var.clients.storagePublic,
             new PutObjectCommand({
-                ACL: "private",
                 Bucket: parameters.var.env.STORAGE_BUCKET_NAME,
                 Key: parameters.storageKey,
                 ContentLength: parameters.contentLength,

--- a/packages/api/src/utilities/storage/putObject.ts
+++ b/packages/api/src/utilities/storage/putObject.ts
@@ -16,7 +16,6 @@ export async function putObject(parameters: {
 }) {
     try {
         const command = new PutObjectCommand({
-            ACL: "private",
             Bucket: parameters.var.env.STORAGE_BUCKET_NAME,
             Key: parameters.storageKey,
             ContentLength: parameters.contentLength,


### PR DESCRIPTION
…ling

- move "Unknown error" log into else branch in server.ts to avoid duplicate logging after known errors
- remove ACL: "private" from PutObjectCommand in generatePutSignedUrl and putObject as some S3-compatible providers do not support ACLs
- remove httpStatusCode 403 from bucket-not-found conditions in ensureStorageBucket
- log warning instead of throwing on non-standard HeadBucket error codes to prevent server crash with providers like OpenStack Swift
- log confirmation message when bucket is accessible