### PR TITLE
fix: fix docker build context and update CI action versions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,8 +13,8 @@ node_modules
 **/node_modules
 
 # Build outputs (generated inside containers)
-build
-**/build
+packages/**/build
+tests/**/build
 dist
 **/dist
 styled-system

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Determine version
         id: version
@@ -32,12 +32,12 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver: docker
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION
- Scope build output exclusion in .dockerignore from **/build to packages/**/build and tests/**/build so .workflows/build/ (nginx configs, Dockerfiles) is included in the Docker build context
- Update GitHub Actions to Node.js 24 variants before June 2 deadline: actions/checkout v4 → v5 docker/setup-buildx-action v3 → v4 docker/login-action v3 → v4