### PR TITLE
ci: move workflow logic to .scripts and fix production Dockerfiles

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -16,10 +16,6 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Upload release assets
-        run: |
-          gh release upload "${{ github.event.release.tag_name }}" \
-            packages/cli/arrhes.sh \
-            packages/cli/install.sh \
-            packages/cli/install.ps1
+        run: .scripts/release-cli.sh "${{ github.event.release.tag_name }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-build-check.yml
+++ b/.github/workflows/pr-build-check.yml
@@ -20,4 +20,4 @@ jobs:
         uses: extractions/setup-just@v2
 
       - name: Run CI build (lint + test + build)
-        run: just build ci
+        run: .scripts/build-ci.sh

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -22,46 +22,26 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Determine version
-        id: version
-        run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            echo "version=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         with:
           driver: docker
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Determine version
+        id: version
+        run: echo "version=$(.scripts/get-version.sh '${{ github.event.release.tag_name }}')" >> "$GITHUB_OUTPUT"
 
-      - name: Build images with docker compose
+      - name: Login to GitHub Container Registry
+        run: .scripts/docker-login.sh
         env:
-          ARRHES_VERSION: ${{ steps.version.outputs.version }}
+          REGISTRY: ${{ env.REGISTRY }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push images
+        run: .scripts/docker-build-and-push.sh "${{ steps.version.outputs.version }}"
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE_PREFIX: ${{ env.IMAGE_PREFIX }}
           VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
           VITE_WEBSITE_BASE_URL: ${{ vars.VITE_WEBSITE_BASE_URL }}
-        run: |
-          docker compose -f .workflows/build/compose.yml build ci
-          docker compose -f .workflows/build/compose.yml build api website worker
-
-      - name: Tag and push images
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          IMAGES=("api" "website" "worker")
-
-          for img in "${IMAGES[@]}"; do
-            SRC="arrhes-${img}:${VERSION}"
-            DEST="${IMAGE_PREFIX}/${img}"
-
-            docker tag "${SRC}" "${DEST}:${VERSION}"
-            docker push "${DEST}:${VERSION}"
-          done

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -6,14 +6,21 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   react-doctor:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: millionco/react-doctor@main
+
+      - uses: pnpm/action-setup@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          diff: main
+          version: 10.26.1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 25
+          cache: pnpm
+
+      - name: Run React Doctor
+        run: .scripts/react-doctor.sh

--- a/.scripts/build-ci.sh
+++ b/.scripts/build-ci.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+just build ci

--- a/.scripts/docker-build-and-push.sh
+++ b/.scripts/docker-build-and-push.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+version="${1:?version argument is required}"
+
+: "${REGISTRY:=ghcr.io}"
+: "${IMAGE_PREFIX:=ghcr.io/arrhes/application}"
+
+export ARRHES_VERSION="$version"
+
+docker compose -f .workflows/build/compose.yml build ci
+docker compose -f .workflows/build/compose.yml build api website worker
+
+for img in api website worker; do
+    src="arrhes-${img}:${version}"
+    dest="${IMAGE_PREFIX}/${img}"
+
+    docker tag "${src}" "${dest}:${version}"
+    docker push "${dest}:${version}"
+done

--- a/.scripts/docker-login.sh
+++ b/.scripts/docker-login.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+: "${REGISTRY:=ghcr.io}"
+: "${GITHUB_ACTOR:?GITHUB_ACTOR is required}"
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+
+printf '%s\n' "$GITHUB_TOKEN" | docker login "$REGISTRY" -u "$GITHUB_ACTOR" --password-stdin

--- a/.scripts/get-version.sh
+++ b/.scripts/get-version.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+release_tag="${1:-}"
+
+if [ -n "$release_tag" ]; then
+    printf '%s\n' "$release_tag"
+else
+    tr -d 'v[:space:]' < VERSION
+fi

--- a/.scripts/react-doctor.sh
+++ b/.scripts/react-doctor.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+pnpm install --frozen-lockfile
+npx react-doctor --staged --fail-on warning

--- a/.scripts/release-cli.sh
+++ b/.scripts/release-cli.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+tag="${1:?release tag argument is required}"
+
+gh release upload "$tag" \
+    packages/cli/arrhes.sh \
+    packages/cli/install.sh

--- a/packages/website/src/features/docs/cli/DemarrerCliDocPage.tsx
+++ b/packages/website/src/features/docs/cli/DemarrerCliDocPage.tsx
@@ -18,11 +18,9 @@ export function DemarrerCliDocPage() {
             <DocSection title="1. Installer le CLI">
                 <DocParagraph>
                     Le CLI est un binaire autonome - aucune installation de Node.js ou de dépendance requise. Collez
-                    l'une des commandes suivantes dans votre terminal :
+                    la commande suivante dans votre terminal :
                 </DocParagraph>
                 <DocCodeBlock>curl -fsSL https://arrhes.com/cli/install.sh | sh</DocCodeBlock>
-                <DocParagraph>Sur Windows (PowerShell) :</DocParagraph>
-                <DocCodeBlock>irm https://arrhes.com/cli/install.ps1 | iex</DocCodeBlock>
                 <DocTip variant="info">
                     Pour les options d'installation avancées (installation manuelle, autres architectures), consultez la{" "}
                     <DocLink to="/documentation/cli/installation">page Installation</DocLink>.


### PR DESCRIPTION
Remove the Windows CLI installer (install.ps1) and all references to it.

Fix incorrect package names in the website and dashboard Dockerfiles so the build stage actually produces output.

Extract inline shell commands from GitHub Actions into .scripts/*.sh so each workflow step is just a script invocation.

Add a react-doctor workflow that runs the CLI directly from a script.