### PR TITLE
ci: move workflow logic to .scripts and fix production Dockerfiles

### DIFF
--- a/.workflows/build/packages/dashboard/Dockerfile
+++ b/.workflows/build/packages/dashboard/Dockerfile
@@ -20,7 +20,7 @@ RUN printf "VITE_API_BASE_URL=%s\nVITE_WEBSITE_BASE_URL=%s\n" \
     "$VITE_API_BASE_URL" "$VITE_WEBSITE_BASE_URL" \
     > packages/dashboard/.env
 
-RUN pnpm --filter @arrhes/application-dashboard... run build
+RUN pnpm --filter @arrhes/dashboard... run build
 
 # Start application
 FROM nginx:alpine AS deploy

--- a/.workflows/build/packages/website/Dockerfile
+++ b/.workflows/build/packages/website/Dockerfile
@@ -21,7 +21,7 @@ RUN printf "VITE_WEBSITE_BASE_URL=%s\nVITE_API_BASE_URL=%s\nVITE_DASHBOARD_BASE_
     "$VITE_WEBSITE_BASE_URL" "$VITE_API_BASE_URL" "$VITE_DASHBOARD_BASE_URL" \
     > packages/website/.env
 
-RUN pnpm --filter @arrhes/application-website... run build
+RUN pnpm --filter @arrhes/website... run build
 
 # Stamp CLI files from VERSION
 RUN VER=$(cat VERSION | tr -d 'v[:space:]') && \


### PR DESCRIPTION
Remove the Windows CLI installer (install.ps1) and all references to it.

Fix incorrect package names in the website and dashboard Dockerfiles so the build stage actually produces output.

Extract inline shell commands from GitHub Actions into .scripts/*.sh so each workflow step is just a script invocation.

Add a react-doctor workflow that runs the CLI directly from a script.