### PR TITLE
fix(api): route ordering — literal paths before param paths

### DIFF
--- a/packages/api/src/routes/auth/organizations/$idOrganization/years/$idYear/entries/entriesRoutes.ts
+++ b/packages/api/src/routes/auth/organizations/$idOrganization/years/$idYear/entries/entriesRoutes.ts
@@ -12,7 +12,9 @@ export const entriesRoutes = [
     readAllEntriesRoute,
     readAllEntryTagsRoute,
 
-    ...$idEntryRoutes,
+    // entryLinesRoutes must come before $idEntryRoutes so that
+    // .../entries/lines matches before .../entries/:idEntry
     ...entryLinesRoutes,
+    ...$idEntryRoutes,
     ...entryTagsRoutes,
 ]

--- a/packages/api/src/routes/auth/organizations/$idOrganization/years/$idYear/yearSettings/computations/$idComputation/$idComputationRoutes.ts
+++ b/packages/api/src/routes/auth/organizations/$idOrganization/years/$idYear/yearSettings/computations/$idComputation/$idComputationRoutes.ts
@@ -5,8 +5,11 @@ import { updateOneComputationRoute } from "./updateOneComputation.js"
 
 export const $idComputationRoutes = [
     deleteOneComputationRoute,
-    readOneComputationRoute,
     updateOneComputationRoute,
 
+    // computationIncomeStatementsRoutes must come before readOneComputation so that
+    // .../computations/income-statements matches before .../computations/:idComputation
     ...computationIncomeStatementsRoutes,
+
+    readOneComputationRoute,
 ]


### PR DESCRIPTION
- entries: entryLinesRoutes (.../entries/lines) registered before (.../entries/:idEntry) so requests to /entries/lines are not greedily caught by /entries/:idEntry with idEntry='lines'
- computations: computationIncomeStatementsRoutes (.../computations/income-statements) registered before readOneComputationRoute (.../computations/:idComputation) for the same reason